### PR TITLE
Change LLM to css agent and add one instuction

### DIFF
--- a/.github/agents/css-expert.agent.md
+++ b/.github/agents/css-expert.agent.md
@@ -2,7 +2,7 @@
 description: "CSS / Sass / Less Expert Agent to create, update, and fix interfaces following CSS, Sass, and Less styles"
 name: "CSS / Sass / Less Expert Agent"
 tools: ['vscode', 'execute', 'read', 'edit', 'search', 'web', 'agent', 'copilot-container-tools/*', 'gitkraken/*', 'github.vscode-pull-request-github/copilotCodingAgent', 'github.vscode-pull-request-github/issue_fetch', 'github.vscode-pull-request-github/suggest-fix', 'github.vscode-pull-request-github/searchSyntax', 'github.vscode-pull-request-github/doSearch', 'github.vscode-pull-request-github/renderIssues', 'github.vscode-pull-request-github/activePullRequest', 'github.vscode-pull-request-github/openPullRequest', 'todo']
-model: GPT-5 mini (copilot)
+model: claude-3.7-sonnet
 ---
 
 # 🎨 CSS / Sass / Less Expert Agent

--- a/.github/instructions/copilot.instructions.md
+++ b/.github/instructions/copilot.instructions.md
@@ -1,0 +1,3 @@
+## Instructions
+
+At the beginning of each iteration, display the name and version of the language model (LLM) being used. Example: "Model in use: GPT-4.1".


### PR DESCRIPTION
This pull request updates the configuration and instructions for our CSS/Sass/Less expert agent and copilot instructions. The most important changes are grouped below:

Agent configuration update:

* Changed the language model for the `.github/agents/css-expert.agent.md` agent from `GPT-5 mini (copilot)` to `claude-3.7-sonnet`, ensuring the agent now uses the latest Claude model.

Copilot instructions improvement:

* Added a new instruction in `.github/instructions/copilot.instructions.md` requiring that the name and version of the language model (LLM) in use be displayed at the start of each iteration, improving transparency for users.