### PR TITLE
tryng LLM options

### DIFF
--- a/.github/agents/css-expert.agent.md
+++ b/.github/agents/css-expert.agent.md
@@ -2,7 +2,7 @@
 description: "CSS / Sass / Less Expert Agent to create, update, and fix interfaces following CSS, Sass, and Less styles"
 name: "CSS / Sass / Less Expert Agent"
 tools: ['vscode', 'execute', 'read', 'edit', 'search', 'web', 'agent', 'copilot-container-tools/*', 'gitkraken/*', 'github.vscode-pull-request-github/copilotCodingAgent', 'github.vscode-pull-request-github/issue_fetch', 'github.vscode-pull-request-github/suggest-fix', 'github.vscode-pull-request-github/searchSyntax', 'github.vscode-pull-request-github/doSearch', 'github.vscode-pull-request-github/renderIssues', 'github.vscode-pull-request-github/activePullRequest', 'github.vscode-pull-request-github/openPullRequest', 'todo']
-model: claude-3.7-sonnet
+model: anthropic:claude-4-sonnet
 ---
 
 # 🎨 CSS / Sass / Less Expert Agent


### PR DESCRIPTION
This pull request updates the AI model used by the CSS / Sass / Less Expert Agent to a newer version, ensuring improved capabilities and performance for interface-related tasks.

* Upgraded the `model` parameter from `claude-3.7-sonnet` to `anthropic:claude-4-sonnet` in `.github/agents/css-expert.agent.md`, enabling the agent to leverage the latest advancements in Anthropic's Claude AI.