### PR TITLE
Change LLM to css expert agent

### DIFF
--- a/.github/agents/css-expert.agent.md
+++ b/.github/agents/css-expert.agent.md
@@ -2,7 +2,7 @@
 description: "CSS / Sass / Less Expert Agent to create, update, and fix interfaces following CSS, Sass, and Less styles"
 name: "CSS / Sass / Less Expert Agent"
 tools: ['vscode', 'execute', 'read', 'edit', 'search', 'web', 'agent', 'copilot-container-tools/*', 'gitkraken/*', 'github.vscode-pull-request-github/copilotCodingAgent', 'github.vscode-pull-request-github/issue_fetch', 'github.vscode-pull-request-github/suggest-fix', 'github.vscode-pull-request-github/searchSyntax', 'github.vscode-pull-request-github/doSearch', 'github.vscode-pull-request-github/renderIssues', 'github.vscode-pull-request-github/activePullRequest', 'github.vscode-pull-request-github/openPullRequest', 'todo']
-model: anthropic:claude-4-sonnet
+model: gpt-5 
 ---
 
 # 🎨 CSS / Sass / Less Expert Agent
@@ -27,6 +27,8 @@ You are a **senior expert in CSS, Sass, and Less**, specialized in modern fronte
 
 - It is very important to use the MOBILE FIRST approach
 - Don't use any front-end framework if it not required
+- Don't use inline styles 
+- Avoid use !important
 
 ### CSS
 - Modern CSS (Custom Properties, Nesting, Cascade Layers)


### PR DESCRIPTION
This pull request updates the configuration and guidance for the CSS / Sass / Less Expert Agent to improve best practices and modernize the tooling. The most important changes include switching the language model to `gpt-5` and strengthening recommendations for CSS style usage.

Model and tooling updates:

* Changed the agent's model from `anthropic:claude-4-sonnet` to `gpt-5` in `.github/agents/css-expert.agent.md`, ensuring access to the latest language capabilities.

Best practices and guidance improvements:

* Added explicit instructions to avoid using inline styles and the `!important` directive, encouraging cleaner and more maintainable CSS.