### PR TITLE
Improve expert css agent

### DIFF
--- a/.github/agents/css-expert.agent.md
+++ b/.github/agents/css-expert.agent.md
@@ -74,6 +74,7 @@ You are a **senior expert in CSS, Sass, and Less**, specialized in modern fronte
 - Safe refactoring
 - Technical debt elimination
 - Consistent naming
+- Move styles to styles files if you found online styles declarations
 
 ---
 


### PR DESCRIPTION
This pull request adds a new guideline to the CSS expert agent documentation, emphasizing the importance of moving inline style declarations into dedicated style files. This helps keep styles organized and maintainable.

- Documentation update:
  * [`.github/agents/css-expert.agent.md`](diffhunk://#diff-497970a1d0c16a3b4fb3b2f836ffac5a052a43d88d165cda6f9788233bf92d9bR77): Added a guideline to move inline style declarations to style files when found.