### PR TITLE
add instructions

### DIFF
--- a/.github/agents/css-expert.agent.md
+++ b/.github/agents/css-expert.agent.md
@@ -2,7 +2,6 @@
 description: "CSS / Sass / Less Expert Agent to create, update, and fix interfaces following CSS, Sass, and Less styles"
 name: "CSS / Sass / Less Expert Agent"
 tools: ['vscode', 'execute', 'read', 'edit', 'search', 'web', 'agent', 'copilot-container-tools/*', 'gitkraken/*', 'github.vscode-pull-request-github/copilotCodingAgent', 'github.vscode-pull-request-github/issue_fetch', 'github.vscode-pull-request-github/suggest-fix', 'github.vscode-pull-request-github/searchSyntax', 'github.vscode-pull-request-github/doSearch', 'github.vscode-pull-request-github/renderIssues', 'github.vscode-pull-request-github/activePullRequest', 'github.vscode-pull-request-github/openPullRequest', 'todo']
-model: gpt-5 
 ---
 
 # 🎨 CSS / Sass / Less Expert Agent

--- a/.github/instructions/copilot.instructions.md
+++ b/.github/instructions/copilot.instructions.md
@@ -1,3 +1,4 @@
 ## Instructions
 
+Set the GPT-4.1 to css-expert agent and Sonnet 3.7 to react-expert agent
 At the beginning of each iteration, display the name and version of the language model (LLM) being used. Example: "Model in use: GPT-4.1".


### PR DESCRIPTION
This pull request updates agent configuration and instructions to clarify which language models are used for specific expert agents. The changes help ensure that the correct model is used for CSS and React-related tasks and improve clarity for contributors.

Agent configuration updates:

* [`.github/agents/css-expert.agent.md`](diffhunk://#diff-497970a1d0c16a3b4fb3b2f836ffac5a052a43d88d165cda6f9788233bf92d9bL5): Removed the `model: gpt-5` line to allow explicit model assignment elsewhere and avoid confusion about the default model for the CSS/Sass/Less expert agent.

Instruction improvements:

* [`.github/instructions/copilot.instructions.md`](diffhunk://#diff-73a4f7e0000f83075fbc7fa6c83a2a9a8d0e7759ffed11d1662aafb317d16411R3): Added a note to set GPT-4.1 for the CSS expert agent and Sonnet 3.7 for the React expert agent, and clarified that the model name and version should be displayed at the start of each iteration.